### PR TITLE
Fix horizontal scrollbar styling in code editor

### DIFF
--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -791,12 +791,12 @@ class NotebookCellWidget(QFrame):
                 border-bottom-right-radius: 4px;
             }}
             QScrollBar::handle:horizontal {{
-                background-color: {self.colors['border_primary']};
+                background-color: {self.colors['scrollbar_handle']};
                 border-radius: 4px;
                 min-width: 30px;
             }}
             QScrollBar::handle:horizontal:hover {{
-                background-color: {self.colors['text_tertiary']};
+                background-color: {self.colors['scrollbar_handle_hover']};
             }}
             QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{
                 width: 0px;

--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -782,6 +782,25 @@ class NotebookCellWidget(QFrame):
                 padding: 4px;
                 font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
             }}
+            QScrollBar:horizontal {{
+                background-color: {self.colors['bg_code']};
+                height: 10px;
+                border: 1px solid {self.colors['border_primary']};
+                border-top: none;
+                border-bottom-left-radius: 4px;
+                border-bottom-right-radius: 4px;
+            }}
+            QScrollBar::handle:horizontal {{
+                background-color: {self.colors['border_primary']};
+                border-radius: 4px;
+                min-width: 30px;
+            }}
+            QScrollBar::handle:horizontal:hover {{
+                background-color: {self.colors['text_tertiary']};
+            }}
+            QScrollBar::add-line:horizontal, QScrollBar::sub-line:horizontal {{
+                width: 0px;
+            }}
         """)
         # Set up syntax highlighting
         self.highlighter = PythonHighlighter(self.source_edit.document(), self.colors)


### PR DESCRIPTION
## Summary
- Adds horizontal scrollbar styling to the code editor (QPlainTextEdit)
- The scrollbar now matches the editor's background color, eliminating the visual gap/missing outline in the corner
- Scrollbar handle uses the border color with a hover effect

## Test plan
- [ ] Open a notebook with a code cell containing a long line that triggers horizontal scrollbar
- [ ] Verify the scrollbar area has consistent styling with no visual gaps
- [ ] Test in dark mode and light mode