### PR TITLE
Auto-discover plugin package in PyQt6 import-smoke test

### DIFF
--- a/tests/test_pyqt6_imports.py
+++ b/tests/test_pyqt6_imports.py
@@ -3,6 +3,10 @@
 This catches short-form Qt enum regressions (for example ``Qt.AlignCenter``
 instead of ``Qt.AlignmentFlag.AlignCenter``) which raise ``AttributeError`` in
 PyQt6 during class-body evaluation.
+
+The plugin package is auto-discovered: the first sibling directory of
+``tests/`` that contains a ``metadata.txt`` is treated as the plugin root,
+so this file does not need to be edited per-plugin.
 """
 
 import importlib
@@ -10,11 +14,32 @@ import pathlib
 
 import pytest
 
-PLUGIN_ROOT = pathlib.Path(__file__).resolve().parent.parent / "qgis_notebook"
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _find_plugin_root() -> pathlib.Path:
+    """Return the plugin package directory (the one with metadata.txt)."""
+    candidates = [
+        p.parent for p in REPO_ROOT.glob("*/metadata.txt") if p.parent.name != "tests"
+    ]
+    if not candidates:
+        raise RuntimeError(
+            "Could not locate a QGIS plugin package (no */metadata.txt found "
+            f"under {REPO_ROOT})."
+        )
+    if len(candidates) > 1:
+        raise RuntimeError(
+            f"Multiple plugin packages found under {REPO_ROOT}: {candidates}. "
+            "Set PLUGIN_ROOT explicitly in this file."
+        )
+    return candidates[0]
+
+
+PLUGIN_ROOT = _find_plugin_root()
 
 
 def _module_names():
-    """Yield dotted module names for every .py file under qgis_notebook/."""
+    """Yield dotted module names for every .py file under the plugin package."""
     for path in sorted(PLUGIN_ROOT.rglob("*.py")):
         rel = path.relative_to(PLUGIN_ROOT.parent).with_suffix("")
         parts = rel.parts


### PR DESCRIPTION
## Summary

- Replace the hard-coded `PLUGIN_ROOT = ... / "qgis_notebook"` in `tests/test_pyqt6_imports.py` with a helper that locates the sibling directory containing `metadata.txt`.
- No behavior change for this repo (still finds `qgis_notebook/`); makes the same test template reusable when dropped into other QGIS plugins without editing.

## Test plan

- [x] `pytest tests -v` under PyQt6 - still 7 passed
- [x] `pre-commit run --files tests/test_pyqt6_imports.py` clean