### PR TITLE
Fix plugins.qgis.org Bandit security scan (v0.7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,19 @@ jobs:
                   python-version: "3.13"
             - uses: pre-commit/action@v3.0.1
 
+    bandit:
+        name: Bandit security scan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - uses: actions/setup-python@v6
+              with:
+                  python-version: "3.13"
+            - name: Install Bandit
+              run: pip install bandit
+            - name: Run Bandit (matches plugins.qgis.org security scan)
+              run: bandit -r qgis_notebook
+
     pyqt6-smoke:
         name: PyQt6 import smoke
         runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,10 @@ repos:
       rev: 0.9.1
       hooks:
           - id: nbstripout
+
+    - repo: https://github.com/PyCQA/bandit
+      rev: 1.9.4
+      hooks:
+          - id: bandit
+            args: ["-r", "qgis_notebook"]
+            pass_filenames: false

--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -292,22 +292,40 @@ class CodeEditor(QPlainTextEdit):
         """)
 
     def _get_completions(self, obj_name):
-        """Get completions for an object."""
-        try:
-            # Try to evaluate the object name in the namespace
-            if "." in obj_name:
-                parts = obj_name.rsplit(".", 1)
-                base = parts[0]
-                obj = eval(base, self.namespace)
-            else:
-                obj = eval(obj_name, self.namespace)
+        """Get completions for an object.
 
-            # Get attributes
+        Resolves obj_name as a dotted attribute chain starting from the
+        notebook namespace. Uses plain dict lookup + getattr rather than
+        eval() so autocomplete cannot be used to execute arbitrary code as
+        the user types.
+        """
+        try:
+            if "." in obj_name:
+                base_name, _, _ = obj_name.rpartition(".")
+                obj = self._resolve_dotted(base_name)
+            else:
+                obj = self.namespace.get(obj_name)
+
+            if obj is None:
+                return []
+
             attrs = dir(obj)
-            # Filter out private attributes unless user typed underscore
             return [a for a in attrs if not a.startswith("_")]
-        except:
+        except Exception:
             return []
+
+    def _resolve_dotted(self, dotted_name):
+        """Walk a dotted attribute chain without eval().
+
+        Returns None if any segment of the chain is missing.
+        """
+        parts = dotted_name.split(".")
+        obj = self.namespace.get(parts[0])
+        for part in parts[1:]:
+            if obj is None:
+                return None
+            obj = getattr(obj, part, None)
+        return obj
 
     def _get_word_before_cursor(self):
         """Get the word/expression before the cursor for completion."""
@@ -2271,7 +2289,15 @@ class NotebookDockWidget(QDockWidget):
             return {"cell_type": "markdown", "metadata": {}, "source": ""}
 
     def _execute_code_sync(self, code):
-        """Execute code synchronously and return result, stdout, stderr."""
+        """Execute code synchronously and return result, stdout, stderr.
+
+        Security note: this plugin is a Jupyter-notebook runner; executing
+        user-authored Python is the feature, not a vulnerability. The
+        namespace is the plugin-local one (``self.namespace``), not builtins,
+        and execution happens only in response to the user running a cell
+        they just typed. The Bandit B307/B102 suppressions below are
+        intentional and documented per QGIS plugin security-scan guidance.
+        """
         old_stdout = sys.stdout
         old_stderr = sys.stderr
         sys.stdout = StringIO()
@@ -2279,12 +2305,14 @@ class NotebookDockWidget(QDockWidget):
 
         result = None
         try:
-            # Try to evaluate as expression first (to get return value)
+            # Try to evaluate as expression first (to get return value).
+            # Executing user-authored notebook code is the feature of this
+            # plugin; see the method docstring for the security rationale.
             try:
-                result = eval(code, self.namespace)
+                result = eval(code, self.namespace)  # nosec B307
             except SyntaxError:
                 # If not an expression, execute as statements
-                exec(code, self.namespace)
+                exec(code, self.namespace)  # nosec B102
 
             stdout = sys.stdout.getvalue()
             stderr = sys.stderr.getvalue()

--- a/qgis_notebook/dialogs/update_checker.py
+++ b/qgis_notebook/dialogs/update_checker.py
@@ -36,6 +36,18 @@ METADATA_URL = f"https://raw.githubusercontent.com/{GITHUB_REPO}/{GITHUB_BRANCH}
 ZIP_URL = f"https://github.com/{GITHUB_REPO}/archive/refs/heads/{GITHUB_BRANCH}.zip"
 
 
+def _require_https(url):
+    """Reject anything that isn't an https:// URL.
+
+    Guards urllib.request.urlopen/urlretrieve against file:/, ftp:, and
+    custom schemes (Bandit B310). The update checker only ever talks to
+    GitHub, so https is the only scheme we expect.
+    """
+    if not isinstance(url, str) or not url.startswith("https://"):
+        raise ValueError(f"Refusing to open non-https URL: {url!r}")
+    return url
+
+
 class VersionCheckWorker(QThread):
     """Worker thread for checking the latest version from GitHub."""
 
@@ -45,7 +57,11 @@ class VersionCheckWorker(QThread):
     def run(self):
         """Fetch the latest metadata from GitHub."""
         try:
-            with urlopen(METADATA_URL, timeout=15) as response:
+            # Scheme is validated in _require_https() above, so the B310
+            # warning about file:/ or custom schemes does not apply here.
+            with urlopen(
+                _require_https(METADATA_URL), timeout=15
+            ) as response:  # nosec B310
                 content = response.read().decode("utf-8")
 
             # Parse version from metadata
@@ -106,7 +122,8 @@ class DownloadWorker(QThread):
                     percent = min(int((downloaded / total_size) * 50), 50)
                     self.progress.emit(10 + percent, "Downloading...")
 
-            urlretrieve(ZIP_URL, zip_path, reporthook)
+            # Scheme validated; see B310 note above.
+            urlretrieve(_require_https(ZIP_URL), zip_path, reporthook)  # nosec B310
 
             self.progress.emit(60, "Extracting files...")
 

--- a/qgis_notebook/metadata.txt
+++ b/qgis_notebook/metadata.txt
@@ -3,7 +3,7 @@ name=Notebook
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Render and run Jupyter notebooks within QGIS in a dockable panel.
-version=0.7.0
+version=0.7.1
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +36,12 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.7.1
+        - Address plugins.qgis.org Bandit security-scan findings
+        - Replace eval() in autocomplete with a safe dotted-attribute walk
+        - Validate https scheme before urlopen/urlretrieve in the update checker
+        - Document the notebook cell executor's intentional use of eval/exec
+        - Wire Bandit into pre-commit and CI to catch regressions
     0.7.0
         - Add compatibility with QGIS 4.0 (Qt6) while keeping QGIS 3.28+ (Qt5) support
         - Qualify Qt enums to the fully scoped form (e.g. Qt.AlignmentFlag.AlignCenter)


### PR DESCRIPTION
## Summary

- The 0.7.0 upload to plugins.qgis.org was blocked by the Bandit security scan (60% pass rate, 1 critical + 1 info). Resolve all 6 findings.
- Replace `eval(name, namespace)` in the autocomplete path with a safe dotted-attribute walk (`dict.get` + `getattr` chain) so typing can never trigger arbitrary code
- Document the notebook cell executor's intentional `eval`/`exec` on user-authored code with a method docstring and `# nosec B307 / B102` on the call lines
- Harden `urlopen` and `urlretrieve` with a `_require_https()` guard and `# nosec B310` annotations so only `https://` URLs are ever accepted
- Wire Bandit into pre-commit (PyCQA/bandit 1.9.4) and a new CI job so regressions are caught locally and in PRs, not at upload time
- Bump version to 0.7.1 and add a changelog entry

After the fix, local `bandit -r qgis_notebook` prints **No issues identified.** with 4 findings properly suppressed via `# nosec BXXX` annotations.

## Test plan

- [x] `bandit -r qgis_notebook` - No issues identified (4 suppressed via # nosec)
- [x] `pre-commit run --all-files` - all hooks pass including the new bandit hook
- [x] `pytest tests/ -v` under PyQt6 - 7/7 modules still import cleanly
- [ ] Re-upload to plugins.qgis.org and confirm the security scan passes
- [ ] Manual smoke in QGIS 3.28: autocomplete still works on `iface.` and dotted expressions
- [ ] Manual smoke: update checker still fetches and downloads