### PR TITLE
Fix blank print() output for QGIS objects (#50)

### DIFF
--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -5,6 +5,7 @@ This module provides the main dockable panel for rendering and executing
 Jupyter notebooks within QGIS.
 """
 
+import html
 import json
 import os
 import sys
@@ -1055,7 +1056,9 @@ class NotebookCellWidget(QFrame):
                 text = output.get("text", [])
                 if isinstance(text, list):
                     text = "".join(text)
-                output_text.append(text)
+                # Escape so object reprs like "<QgsField: ...>" are not
+                # swallowed as HTML tags by the rich-text widget.
+                output_text.append(html.escape(text))
 
             elif output_type in ("execute_result", "display_data"):
                 data = output.get("data", {})
@@ -1063,13 +1066,14 @@ class NotebookCellWidget(QFrame):
                     text = data["text/plain"]
                     if isinstance(text, list):
                         text = "".join(text)
-                    output_text.append(text)
+                    output_text.append(html.escape(text))
 
             elif output_type == "error":
                 ename = output.get("ename", "Error")
                 evalue = output.get("evalue", "")
                 output_text.append(
-                    f"<span style='color:{self.colors['text_error']};'>{ename}: {evalue}</span>"
+                    f"<span style='color:{self.colors['text_error']};'>"
+                    f"{html.escape(f'{ename}: {evalue}')}</span>"
                 )
 
         if output_text:
@@ -1120,17 +1124,21 @@ class NotebookCellWidget(QFrame):
         output_parts = []
 
         if stdout:
-            # Strip trailing newline to avoid extra blank line
-            output_parts.append(stdout.rstrip("\n"))
+            # Strip trailing newline to avoid extra blank line. Escape so that
+            # object reprs like "<QgsField: name (type)>" are shown literally
+            # instead of being swallowed as HTML tags by the rich-text widget.
+            output_parts.append(html.escape(stdout.rstrip("\n")))
 
         if result is not None:
             output_parts.append(
-                f"<span style='color:{self.colors['text_output']};'>{repr(result)}</span>"
+                f"<span style='color:{self.colors['text_output']};'>"
+                f"{html.escape(repr(result))}</span>"
             )
 
         if stderr:
             output_parts.append(
-                f"<span style='color:{self.colors['text_error']};'>{stderr}</span>"
+                f"<span style='color:{self.colors['text_error']};'>"
+                f"{html.escape(stderr)}</span>"
             )
 
         if output_parts:

--- a/qgis_notebook/metadata.txt
+++ b/qgis_notebook/metadata.txt
@@ -3,7 +3,7 @@ name=Notebook
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Render and run Jupyter notebooks within QGIS in a dockable panel.
-version=0.7.1
+version=0.7.2
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +36,8 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.7.2
+        - Fix print() output of QGIS objects showing as blank lines (#50)
     0.7.1
         - Address plugins.qgis.org Bandit security-scan findings
         - Replace eval() in autocomplete with a safe dotted-attribute walk


### PR DESCRIPTION
## Summary

Fixes #50. Printing QGIS objects in a notebook cell — e.g.

```python
layer = iface.activeLayer()
for item in layer.fields():
    print(item)
```

produced a **blank line** per item instead of the field text, while the QGIS Python console printed them correctly.

## Root cause

Cell output is rendered into the rich-text output widget with `setHtml()`. The captured `stdout`/`stderr` and result `repr` were inserted **without HTML-escaping**. QGIS object reprs look like HTML tags (e.g. `<QgsField: name (type)>` or `<qgis._core.QgsField object at 0x…>`), so the rich-text widget interpreted them as unknown tags and silently dropped them — leaving only the newline `print()` adds, i.e. a blank line.

## Fix

HTML-escape plain-text output before rendering, in both output paths:

- `CellWidget.set_output` — live execution: `stdout`, `stderr`, and `repr(result)`.
- `CellWidget._display_outputs` — loaded-notebook outputs: stream text, `text/plain` results, and error `ename: evalue`.

Markdown rendering (which intentionally emits HTML) is untouched.

Bumps version to 0.7.2 and adds a changelog entry.

## Testing

- `python -m py_compile` passes.
- Verified `html.escape("<QgsField: name (QString)>")` → `&lt;QgsField: name (QString)&gt;`, which the widget now displays literally instead of dropping.