### PR TITLE
Fix color-scheme switching and invisible cell menu text (#53)

### DIFF
--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -643,6 +643,10 @@ class NotebookCellWidget(QFrame):
     def _clear_cell_output(self):
         """Clear the output of this cell."""
         self._last_output = None
+        # Also drop the persisted outputs so they don't reappear when the cell
+        # is rebuilt (theme change) or the notebook is saved/reloaded.
+        if "outputs" in self.cell_data:
+            self.cell_data["outputs"] = []
         if self.cell_type == "code" and hasattr(self, "output_area"):
             self.output_area.clear()
             self.output_area.setVisible(False)
@@ -1656,6 +1660,8 @@ class NotebookDockWidget(QDockWidget):
         # is loaded and restore each cell's captured output.
         if self.notebook_data and self.notebook_data.get("cells"):
             self._render_notebook()
+            # _setup_ui() reset path_edit to its placeholder; restore the path.
+            self.path_edit.setText(self.notebook_path or "Untitled.ipynb")
             for widget, output in zip(self.cell_widgets, outputs):
                 if (
                     output is not None
@@ -2569,8 +2575,7 @@ class NotebookDockWidget(QDockWidget):
         """Clear all cell outputs."""
         for widget in self.cell_widgets:
             if isinstance(widget, NotebookCellWidget) and widget.cell_type == "code":
-                widget.output_area.clear()
-                widget.output_area.setVisible(False)
+                widget._clear_cell_output()
 
         self.status_bar.setText("Outputs cleared")
         self.status_bar.setStyleSheet(f"""

--- a/qgis_notebook/dialogs/notebook_dock.py
+++ b/qgis_notebook/dialogs/notebook_dock.py
@@ -582,6 +582,9 @@ class NotebookCellWidget(QFrame):
         self._editing_markdown = False
         self._is_focused = False
         self._is_selected = False  # Track selection state (for command mode)
+        # Last (result, stdout, stderr) shown, so it can be restored when the
+        # notebook is rebuilt (e.g. after a color-scheme change).
+        self._last_output = None
 
         self.setFrameStyle(QFrame.Shape.StyledPanel | QFrame.Shadow.Raised)
         # Prevent cell from expanding vertically beyond its content
@@ -639,13 +642,48 @@ class NotebookCellWidget(QFrame):
 
     def _clear_cell_output(self):
         """Clear the output of this cell."""
+        self._last_output = None
         if self.cell_type == "code" and hasattr(self, "output_area"):
             self.output_area.clear()
             self.output_area.setVisible(False)
 
+    def _menu_stylesheet(self):
+        """Return a QMenu stylesheet using the current theme colors.
+
+        Without an explicit stylesheet the menu inherits colors from the
+        styled cell frame, which can render text the same color as the
+        background (invisible until hovered).
+        """
+        return f"""
+            QMenu {{
+                background-color: {self.colors['bg_secondary']};
+                color: {self.colors['text_primary']};
+                border: 1px solid {self.colors['border_primary']};
+                padding: 4px;
+            }}
+            QMenu::item {{
+                background-color: transparent;
+                color: {self.colors['text_primary']};
+                padding: 5px 24px;
+            }}
+            QMenu::item:selected {{
+                background-color: {self.colors['bg_button_hover']};
+                color: {self.colors['text_primary']};
+            }}
+            QMenu::item:disabled {{
+                color: {self.colors['text_tertiary']};
+            }}
+            QMenu::separator {{
+                height: 1px;
+                background-color: {self.colors['border_primary']};
+                margin: 4px 8px;
+            }}
+        """
+
     def _show_context_menu(self, pos):
         """Show context menu for cell operations."""
         menu = QMenu(self)
+        menu.setStyleSheet(self._menu_stylesheet())
 
         # Add cell actions
         add_code_above = menu.addAction("Add Code Cell Above")
@@ -1118,6 +1156,10 @@ class NotebookCellWidget(QFrame):
 
     def set_output(self, result, stdout, stderr):
         """Set the output of the cell after execution."""
+        # Remember the raw output so it can be restored if the cell widget is
+        # rebuilt (e.g. when the color scheme changes).
+        self._last_output = (result, stdout, stderr)
+
         # Clear previous output first
         self.output_area.clear()
 
@@ -1193,6 +1235,7 @@ class NotebookCellWidget(QFrame):
     def _show_cell_type_menu(self):
         """Show a dropdown menu to change the cell type."""
         menu = QMenu(self)
+        menu.setStyleSheet(self._menu_stylesheet())
 
         code_action = menu.addAction("Code")
         markdown_action = menu.addAction("Markdown")
@@ -1570,6 +1613,56 @@ class NotebookDockWidget(QDockWidget):
                 "scrollbar_handle": "#4E5254",
                 "scrollbar_handle_hover": "#6E7274",
             }
+
+    def _sync_sources_to_data(self):
+        """Write current cell editor contents back into ``notebook_data``.
+
+        Keeps in-progress (unsaved) edits when the notebook is rebuilt.
+        """
+        if not self.notebook_data:
+            return
+        cells = self.notebook_data.get("cells", [])
+        for i, widget in enumerate(self.cell_widgets):
+            if isinstance(widget, NotebookCellWidget) and i < len(cells):
+                cells[i]["source"] = widget.get_source()
+
+    def refresh_theme(self):
+        """Reload the color scheme and rebuild the UI to apply it.
+
+        Rebuilds the whole panel because the palette is baked into each
+        widget's stylesheet at construction time. In-progress edits and
+        cell outputs are preserved across the rebuild.
+        """
+        # Capture current editor contents and live outputs before the old
+        # widgets are destroyed by the rebuild.
+        self._sync_sources_to_data()
+        outputs = [
+            widget._last_output if isinstance(widget, NotebookCellWidget) else None
+            for widget in self.cell_widgets
+        ]
+
+        # Reload colors from settings and rebuild the UI with the new palette.
+        # setWidget() detaches but does not delete the previous widget tree, so
+        # delete it explicitly to avoid leaking it on every theme change.
+        old_widget = self.widget()
+        # Pick up values written by the (separate) settings dock's QSettings.
+        self.settings.sync()
+        self._load_theme()
+        self._setup_ui()
+        if old_widget is not None:
+            old_widget.deleteLater()
+
+        # _setup_ui() shows the welcome screen; re-render the notebook if one
+        # is loaded and restore each cell's captured output.
+        if self.notebook_data and self.notebook_data.get("cells"):
+            self._render_notebook()
+            for widget, output in zip(self.cell_widgets, outputs):
+                if (
+                    output is not None
+                    and isinstance(widget, NotebookCellWidget)
+                    and widget.cell_type == "code"
+                ):
+                    widget.set_output(*output)
 
     def _update_cell_namespaces(self):
         """Update the namespace in all cell widgets for autocomplete."""

--- a/qgis_notebook/dialogs/settings_dock.py
+++ b/qgis_notebook/dialogs/settings_dock.py
@@ -5,7 +5,7 @@ This module provides a settings panel for configuring
 the notebook plugin options.
 """
 
-from qgis.PyQt.QtCore import Qt, QSettings
+from qgis.PyQt.QtCore import Qt, QSettings, pyqtSignal
 from qgis.PyQt.QtWidgets import (
     QDockWidget,
     QWidget,
@@ -28,6 +28,10 @@ from qgis.PyQt.QtGui import QFont
 
 class SettingsDockWidget(QDockWidget):
     """A settings panel for configuring notebook plugin options."""
+
+    # Emitted after settings are saved so open panels can re-apply them
+    # (e.g. the notebook dock reloading its color scheme).
+    settings_changed = pyqtSignal()
 
     # Settings keys
     SETTINGS_PREFIX = "QGISNotebook/"
@@ -536,6 +540,10 @@ class SettingsDockWidget(QDockWidget):
 
         self.status_label.setText("Settings saved")
         self.status_label.setStyleSheet("color: #6AAB73; font-size: 10px;")
+
+        # Notify listeners (e.g. the notebook dock) so changes such as the
+        # color scheme are applied immediately without reopening the panel.
+        self.settings_changed.emit()
 
         self.iface.messageBar().pushSuccess(
             "QGIS Notebook", "Settings saved successfully!"

--- a/qgis_notebook/metadata.txt
+++ b/qgis_notebook/metadata.txt
@@ -3,7 +3,7 @@ name=Notebook
 qgisMinimumVersion=3.28
 qgisMaximumVersion=4.99
 description=Render and run Jupyter notebooks within QGIS in a dockable panel.
-version=0.7.2
+version=0.7.3
 author=Qiusheng Wu
 email=giswqs@gmail.com
 
@@ -36,6 +36,9 @@ experimental=False
 deprecated=False
 
 changelog=
+    0.7.3
+        - Apply color scheme changes immediately without reopening the panel (#53)
+        - Fix invisible (black-on-black) cell context menu text (#53)
     0.7.2
         - Fix print() output of QGIS objects showing as blank lines (#50)
     0.7.1

--- a/qgis_notebook/qgis_notebook.py
+++ b/qgis_notebook/qgis_notebook.py
@@ -325,9 +325,7 @@ class QGISNotebook:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
-                self._settings_dock.settings_changed.connect(
-                    self._on_settings_changed
-                )
+                self._settings_dock.settings_changed.connect(self._on_settings_changed)
                 self.iface.addDockWidget(
                     Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
                 )

--- a/qgis_notebook/qgis_notebook.py
+++ b/qgis_notebook/qgis_notebook.py
@@ -325,6 +325,9 @@ class QGISNotebook:
                 self._settings_dock.visibilityChanged.connect(
                     self._on_settings_visibility_changed
                 )
+                self._settings_dock.settings_changed.connect(
+                    self._on_settings_changed
+                )
                 self.iface.addDockWidget(
                     Qt.DockWidgetArea.RightDockWidgetArea, self._settings_dock
                 )
@@ -351,6 +354,11 @@ class QGISNotebook:
     def _on_settings_visibility_changed(self, visible):
         """Handle Settings dock visibility change."""
         self.settings_action.setChecked(visible)
+
+    def _on_settings_changed(self):
+        """Re-apply settings (e.g. color scheme) to the open notebook dock."""
+        if self._notebook_dock is not None:
+            self._notebook_dock.refresh_theme()
 
     def show_about(self):
         """Display the about dialog."""


### PR DESCRIPTION
## Summary

Fixes #53, which reported two theme-related problems:

1. **Switching the color scheme does nothing.**
2. **The cell right-click context menu is invisible** — black text on a black background, legible only while an item is hovered.

## Root causes

1. `SettingsDockWidget._save_settings` wrote the color scheme to `QSettings` but emitted no notification, so the already-built notebook dock never re-applied it. The palette is baked into each widget's stylesheet at construction time, so a saved setting had no effect until the panel was recreated.
2. The cell context menus created a bare `QMenu` with no stylesheet. It inherited colors from the styled cell frame, ending up with menu-item text the same color as the menu background — invisible until the `:selected` (hover) state kicked in.

## Fix

**Color scheme now applies live:**
- Add a `settings_changed` signal to `SettingsDockWidget`, emitted after `_save_settings` syncs.
- Wire it in the plugin (`_on_settings_changed`) to call a new `NotebookDockWidget.refresh_theme()`.
- `refresh_theme()` reloads the palette and rebuilds the panel, **preserving in-progress (unsaved) cell edits and cell outputs**. It also `sync()`s `QSettings` (the two docks use separate instances) and deletes the old widget tree to avoid leaking it on each change.

**Context menu is readable:**
- Add a theme-aware `_menu_stylesheet()` and apply it to both the cell context menu and the cell-type menu, with explicit background/text/selected/disabled/separator colors.

Bumps version to 0.7.3 with changelog entries.

## Testing

- `python -m py_compile` passes for all changed modules.
- Full manual verification requires a running QGIS session (not available in this environment); logic was traced against the existing data flow (source sync mirrors `_save_to_path`, output restore reuses `set_output`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Theme and color scheme updates now apply immediately to open notebook panels after settings changes.
  - Notebook cell execution outputs are preserved during interface refreshes.
  - Cell context menus and cell type dropdown menus now match the selected theme consistently.
- **Bug Fixes**
  - Fixed dark-theme issue where cell context menu text could be invisible.
- **Chores**
  - Updated the plugin version to 0.7.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->